### PR TITLE
[APPAI-1733] Created github utility to raise PR and get content for repos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,3 +80,4 @@ websocket-client==0.54.0
 Werkzeug==0.15.3
 wrapt==1.11.1
 xmltodict==0.12.0
+PyGithub==1.54.1

--- a/rudra/utils/github_utils.py
+++ b/rudra/utils/github_utils.py
@@ -1,0 +1,70 @@
+# Copyright © 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Dharmendra G Patel <dhpatel@redhat.com>
+#
+"""Github utility providing functionality to read and write github resource."""
+from github import Github
+
+
+class GithubUtils:
+    """Class to perform action related to github like get content / raise PR etc."""
+
+    def __init__(self, github_token):
+        """Get github token to initialize the class."""
+        # Create github object using token
+        self._github = Github(github_token)
+
+    def set_repo(self, repo_path, master_ref='master'):
+        """Setup repo and master ref details."""
+        self._master_ref = master_ref
+
+        # Get repo and set to private member
+        self._repo = self._github.get_repo(repo_path)
+
+    def get_latest_commit_hash(self):
+        """Get the latest commit hash of the repo."""
+        # Read all commits for a repo.
+        commits = self._repo.get_commits()
+
+        # Read the latest commit of the repo at index '0'
+        latest_commit_hash = commits[0].sha
+
+        return latest_commit_hash
+
+    def create_branch(self, branch_name):
+        """Create a branch with latest code."""
+        # Create branch with latest commit
+        ref = self._repo.create_git_ref('refs/heads/' + branch_name,
+                                        self.get_latest_commit_hash())
+        return ref.url
+
+    def get_content(self, file_path):
+        """Read and returns content of the given file path within repo."""
+        # Read file content of a path relative to repo root directory.
+        contents = self._repo.get_contents(file_path)
+        return contents.sha, contents.decoded_content
+
+    def update_content(self, branch_name, file_path, update_message, current_sha, file_content):
+        """Update the file content for path."""
+        # Up on given branch it willl update the file content
+        update = self._repo.update_file(file_path, update_message, file_content, current_sha,
+                                        branch="refs/heads/" + branch_name)
+        return update['commit'].sha
+
+    def create_pr(self, branch_name, title, body):
+        """Raise the PR to merge changes from branch to master."""
+        pr = self._repo.create_pull(title=title, body=body, head="refs/heads/" + branch_name,
+                                    base="refs/heads/" + self._master_ref)
+        return pr.number

--- a/tests/utils/test_github_utils.py
+++ b/tests/utils/test_github_utils.py
@@ -1,9 +1,0 @@
-"""Tests for SimpleMercator class."""
-
-import pytest
-
-from rudra.utils.github_utils import GithubUtils
-
-
-class TestSimpleGithubUtils:
-    def

--- a/tests/utils/test_github_utils.py
+++ b/tests/utils/test_github_utils.py
@@ -1,0 +1,9 @@
+"""Tests for SimpleMercator class."""
+
+import pytest
+
+from rudra.utils.github_utils import GithubUtils
+
+
+class TestSimpleGithubUtils:
+    def


### PR DESCRIPTION
# Description

Added a common github utility to raise PR and work with github content. This utility will replace the plain shell script used for raising saas pr during re-training pipeline. This utility is generic and can be used by any component to read content for a github repo, raise PRs, create branches etc.

Fixes # (issue)
https://issues.redhat.com/browse/APPAI-1733

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
